### PR TITLE
update cheerio search property

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@yeehawitsjakester/node-get-youtube-id-by-url:registry=https://npm.pkg.github.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-@yeehawitsjakester/node-get-youtube-id-by-url:registry=https://npm.pkg.github.com
+@yeehawitsjakester/node-get-youtube-id-by-url:registry=https://npm.pkg.github.com/yeehawitsjakester//npm.pkg.github.com/:_authToken=readWriteToken

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gonetone/get-youtube-id-by-url",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Get YouTube channel or video id by url!",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/GoneToneStudio/node-get-youtube-id-by-url.git"
+    "url": "https://github.com/yeehawitsjakester/node-get-youtube-id-by-url.git"
   },
   "keywords": [
     "youtube",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gonetone/get-youtube-id-by-url",
+  "name": "@yeehawitsjakester/node-get-youtube-id-by-url",
   "version": "1.0.1",
   "description": "Get YouTube channel or video id by url!",
   "main": "index.js",

--- a/src/GetYouTubeIdByUrl.js
+++ b/src/GetYouTubeIdByUrl.js
@@ -34,10 +34,11 @@
 
 const axios = require('axios')
 const cheerio = require('cheerio')
+const {remove} = require("cheerio/lib/api/manipulation");
 
 const axiosInstance = axios.create({
   headers: {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36'
+    'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/117.0'
   },
   validateStatus: () => {
     return true
@@ -62,13 +63,12 @@ const channelId = async (url) => {
   if (checkUrl(url)) {
     const ytChannelPageResponse = await axiosInstance.get(url)
     const $ = cheerio.load(ytChannelPageResponse.data)
-
-    const id = $('meta[itemprop="channelId"]').attr('content')
+    const id = $('meta[itemprop="identifier"]').attr('content')  //updated itemprop. YouTube appears to have updated this since last commit.
     if (id) {
       return id
     }
   } else {
-    throw Error(`"${url}" is not a YouTube url.`)
+    throw Error(`"${url}" is not a YouTube channel.`)
   }
 
   throw Error(`Unable to get "${url}" channel id.`)
@@ -85,12 +85,12 @@ const videoId = async (url) => {
     const ytChannelPageResponse = await axiosInstance.get(url)
     const $ = cheerio.load(ytChannelPageResponse.data)
 
-    const id = $('meta[itemprop="videoId"]').attr('content')
+    const id = $('meta[itemprop="identifier"]').attr('content')  //apparently same goes for videos?
     if (id) {
       return id
     }
   } else {
-    throw Error(`"${url}" is not a YouTube url.`)
+    throw Error(`"${url}" is not a YouTube video.`)
   }
 
   throw Error(`Unable to get "${url}" video id.`)

--- a/src/GetYouTubeIdByUrl.js
+++ b/src/GetYouTubeIdByUrl.js
@@ -34,7 +34,6 @@
 
 const axios = require('axios')
 const cheerio = require('cheerio')
-const {remove} = require("cheerio/lib/api/manipulation");
 
 const axiosInstance = axios.create({
   headers: {

--- a/tests/GetYouTubeIdByUrl.test.js
+++ b/tests/GetYouTubeIdByUrl.test.js
@@ -37,9 +37,9 @@ const { channelId, videoId } = require('..')
 test('Get YouTube Channel ID By Url', async () => {
   const id = await channelId('https://www.youtube.com/c/GoneTone')
   expect(id).toBe('UCYLtQ2gBXAnG6WaurcoZ7kg')
-}, 1000)
+}, 10000) //im on a mobile data connection right now i dont wanna hear anything about my timeout value is too high :(
 
 test('Get YouTube Video ID By Url', async () => {
   const id = await videoId('https://youtu.be/PB4gId2mPNc')
   expect(id).toBe('PB4gId2mPNc')
-}, 1000)
+}, 10000)


### PR DESCRIPTION
i know theres a few different properties here but the identifier on both videos and channels should be updated to $('meta[itemprop="identifier"]').attr('content') as this shows the video ID (if on a YouTube video) or the Channel ID (if only viewing the channel). nothing serious